### PR TITLE
Bug header size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ test: uninstall install
 	cd tests && nosetests -v --with-coverage --cover-package=vlab_cee_api
 
 images: build
-	sudo docker build -f ApiDockerfile -t willnx/vlab-cee-api .
-	sudo docker build -f WorkerDockerfile -t willnx/vlab-cee-worker .
+	docker build -f ApiDockerfile -t willnx/vlab-cee-api .
+	docker build -f WorkerDockerfile -t willnx/vlab-cee-worker .
 
 up:
 	docker-compose -p vlabcee up --abort-on-container-exit

--- a/vlab_cee_api/app.ini
+++ b/vlab_cee_api/app.ini
@@ -11,3 +11,4 @@ uid = nobody
 gid = nobody
 disable-logging = true
 enabled-threads = True
+buffer-size=32768


### PR DESCRIPTION
The auth token contains group membership information. If a user (like me) is part of _a lot_ of groups, then the HTTP header can become too big for uWSG to accept. Simple fix; just increase the max header sized uWSGI allows.